### PR TITLE
Fixed Command Injection

### DIFF
--- a/lib/imagickal.js
+++ b/lib/imagickal.js
@@ -1,6 +1,6 @@
 'use strict';
 const Promise = require('bluebird');
-const exec = require('child_process').exec;
+const execFile = require('child_process').execFile;
 const printf = require('util').format;
 const stream = require('stream');
 const Readable = stream.Readable;
@@ -57,12 +57,16 @@ function parseOutput(output) {
  *                     images attriube shows number of images in sequence. eg for an animated gif
  */
 exports.dimensions = function (path, callback) {
-	const cmd = 'identify -format "{\\"width\\":%w,\\"height\\":%h}" ' + (path instanceof Readable ? '-' : path);
+	const cmd = [
+		'-format',
+		'"{\\"width\\":%w,\\"height\\":%h}"',
+		(path instanceof Readable ? '-' : path)
+	];
 
 	const promise = new Promise((resolve, reject) => {
 		debug('dimensions', cmd);
 
-		const shell = exec(cmd, Object.assign({ stdio: ['pipe'] }, globalOpts.execOptions || {}), (err, stdout) => {
+		const shell = execFile('identify', cmd, Object.assign({ stdio: ['pipe'] }, globalOpts.execOptions || {}), (err, stdout) => {
 			if (err) {
 				return reject(err);
 			}

--- a/lib/imagickal.js
+++ b/lib/imagickal.js
@@ -104,16 +104,17 @@ exports.identify = function (path, verifyImage, callback) {
 		verifyImage = false;
 	}
 
-	const cmd = printf(
-		'identify -format "{\\"format\\":\\"%m\\",\\"width\\":%w,\\"height\\":%h}" %s%s',
-		verifyImage ? '-verbose ' : '',
-		path instanceof Readable ? '-' : path
-	);
+	const cmd = [
+		'-format',
+		printf('"{\\"format\\":\\"%m\\",\\"width\\":%w,\\"height\\":%h}" %s%s'),
+	      	(verifyImage ? '-verbose ' : ''),
+	      	(path instanceof Readable ? '-' : path)
+	];
 
 	debug('identify', cmd);
 
 	const promise = new Promise((resolve, reject) => {
-		const shell = exec(cmd, Object.assign({ stdio: ['pipe'] }, globalOpts.execOptions || {}), (err, stdout) => {
+		const shell = exec('identify', cmd, Object.assign({ stdio: ['pipe'] }, globalOpts.execOptions || {}), (err, stdout) => {
 			if (err) {
 				if (err.message.match(/decode delegate/)) {
 					return reject(new Error('Invalid image file'));


### PR DESCRIPTION
### ⚙️ Description *

The vulnerability is caused due to the usage of `child_process`'s `exec()` function which is vulnerable to Command Injection. Replacing the `exec()` function with `execFile()` function will mitigate this vulnerability.

### 💻 Technical Description *

The occurrence of this vulnerability is caused due to the usage of the `exec()` function. So replacing the `exec()` function with `execFile()` is enough to fix the issue.

Here is how it works:

```javascript
const cmd = [
	'-format',
	'"{\\"width\\":%w,\\"height\\":%h}"',
	(path instanceof Readable ? '-' : path)
];

const promise = new Promise((resolve, reject) => {
	debug('dimensions', cmd);

	const shell = execFile('identify', cmd, Object.assign({ stdio: ['pipe'] }, globalOpts.execOptions || {}), (err, stdout) => {
		// ...
	});

	if (path instanceof Readable) {
		path.pipe(shell.stdin);
	}
});

return promise.asCallback(callback);
```

Here the utility used is `identify` so that is set as the binary file for the `execFile()` function. So the `identify` element from `cmd[]` array is taken out to just pass as an argument array to `execFile()`.

### 🐛 Proof of Concept (PoC) *

_**To be placed in the root folder of the project (`poc.js`)**_
```javascript
// poc.js
var im = require('./index.js');

im.dimensions('image.jpg; touch HACKED; #').then(function (dim) {
    console.log(dim.width);
    console.log(dim.height);
});
```

### 🔥 Proof of Fix (PoF) *

    $ cd node-imagickal/
    $ npm install
    $ node poc.js

![node-imagickal-fix](https://user-images.githubusercontent.com/26198477/81425157-ab09c700-9174-11ea-9f2a-7bb706895558.png)

In the above screenshot, you can see that no file named `HACKED` has been created thus fixing the issue.

### 👍 User Acceptance Testing (UAT)

The replacement of the `exec()` function with `execFile()` is the only change implemented.

### 📊 Metadata *

#### Bounty URL:

https://www.huntr.dev/app/bounties/open/1-npm-node-imagickal