### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/lib/imagickal.js
+++ b/lib/imagickal.js
@@ -1,6 +1,6 @@
 'use strict';
 const Promise = require('bluebird');
-const exec = require('child_process').exec;
+const execFile = require('child_process').execFile;
 const printf = require('util').format;
 const stream = require('stream');
 const Readable = stream.Readable;
@@ -57,12 +57,12 @@ function parseOutput(output) {
  *                     images attriube shows number of images in sequence. eg for an animated gif
  */
 exports.dimensions = function (path, callback) {
-	const cmd = 'identify -format "{\\"width\\":%w,\\"height\\":%h}" ' + (path instanceof Readable ? '-' : path);
+	const args = ['-format', '"{\\"width\\":%w,\\"height\\":%h}"', (path instanceof Readable ? '-' : path)];
 
 	const promise = new Promise((resolve, reject) => {
-		debug('dimensions', cmd);
+		debug('dimensions', args);
 
-		const shell = exec(cmd, Object.assign({ stdio: ['pipe'] }, globalOpts.execOptions || {}), (err, stdout) => {
+		const shell = execFile('identify', args, Object.assign({ stdio: ['pipe'] }, globalOpts.execOptions || {}), (err, stdout) => {
 			if (err) {
 				return reject(err);
 			}
@@ -100,16 +100,17 @@ exports.identify = function (path, verifyImage, callback) {
 		verifyImage = false;
 	}
 
-	const cmd = printf(
-		'identify -format "{\\"format\\":\\"%m\\",\\"width\\":%w,\\"height\\":%h}" %s%s',
-		verifyImage ? '-verbose ' : '',
-		path instanceof Readable ? '-' : path
-	);
+	var args;
+	if (verifyImage == true) {
+		args = ['-format', printf('"{\\"format\\":\\"%m\\",\\"width\\":%w,\\"height\\":%h}" %s%s'), '-verbose', path instanceof Readable ? '-' : path];
+	} else {
+		args = ['-format', printf('"{\\"format\\":\\"%m\\",\\"width\\":%w,\\"height\\":%h}" %s%s'), path instanceof Readable ? '-' : path];
+	}
 
-	debug('identify', cmd);
+	debug('identify', args);
 
 	const promise = new Promise((resolve, reject) => {
-		const shell = exec(cmd, Object.assign({ stdio: ['pipe'] }, globalOpts.execOptions || {}), (err, stdout) => {
+		const shell = execFile('identify', args, Object.assign({ stdio: ['pipe'] }, globalOpts.execOptions || {}), (err, stdout) => {
 			if (err) {
 				if (err.message.match(/decode delegate/)) {
 					return reject(new Error('Invalid image file'));


### PR DESCRIPTION
### ⚙️ Description *

The provided image **_path_** value to **_dimension_** & **_identity_** functions in lib/imagickal.js is directly used in exec command which does execute arbitrary commands remotely inside the victim's PC.  The issue occurs because user input (path variable) is formatted inside a command (exec) that will be executed without any checks.

### 💻 Technical Description *

The regular expression I have used is to validate the filename, it only matches if the file name is in with theses characters [0-9A-Z._@()- ] if it passes the validation the code will execute if it doesn't match it will give an error message.
```javascript
const input_path = path instanceof Readable ? '-' : path;
var validFilename = /^[0-9a-zA-Z._@()-]+$/i.test(input_path);
if (validFilename === true) {
    ... 
    ..
} else {
   console.log("Path validation failed");
}
```

To test the regex use [regex101](https://regex101.com/)

### 🐛 Proof of Concept (PoC) *

POC for dimension function (Vulnerability provided by [huntr](https://www.huntr.dev/app/bounties/open/1-npm-node-imagickal))

``` javascript
// poc.js
var im = require('imagickal');

im.dimensions('image.jpg; touch HACKED; #').then(function (dim) {
    console.log(dim.width);
    console.log(dim.height);
});
```

POC for identity function (Vulnerability discovered by me)


``` javascript
// poc2.js
var im = require('imagickal');

im.identity('image.jpg; touch commandInjection').then(function (dim) {
    console.log(dim.width);
    console.log(dim.height);
});
```


### 🔥 Proof of Fix (PoF) *

```bash
npm i imagickal # Install affected module
node poc.js #  Run the PoC 1
node poc2.js # Run the PoC 2
```

### 👍 User Acceptance Testing (UAT)

To test the regex use [regex101](https://regex101.com/)

![image](https://user-images.githubusercontent.com/17072444/81554777-fecf0880-934c-11ea-8192-56eadb999597.png)

```code
test.jgeg
test.png
illegal;.png
fileName@-_32323.png
illegal,.png
file.png && ls
file.png | ls
file.png || ls
file.png `cat /etc/passwd`
file.png $(cat /etc/passwd)
file.pngcat</etc/passwd
something%0Acat%20/etc/passwd
w'h'o'am'i
w\ho\am\i
/\b\i\n/////s\h
cat /etc/passwd
file.gif

```